### PR TITLE
query parameter shortcode

### DIFF
--- a/shortcodes-wp.php
+++ b/shortcodes-wp.php
@@ -36,3 +36,15 @@ function user_lastname($atts) {
 // wordpress hook
 add_shortcode('wpuser_firstname', 'user_firstname');
 add_shortcode('wpuser_lastname', 'user_lastname');
+
+// query string shortcode
+add_shortcode('wpuser_query_string', 'get_query_string');
+function get_query_string($atts){
+    $atts = shortcode_atts( array(
+        'arg' => false,
+    ), $atts);
+
+    $query_string = isset( $_GET[ $atts['arg'] ] ) ? sanitize_text_field( $_GET[ $atts['arg'] ] ) : false;
+
+    return $query_string;
+}

--- a/shortcodes-wp.php
+++ b/shortcodes-wp.php
@@ -37,14 +37,12 @@ function user_lastname($atts) {
 add_shortcode('wpuser_firstname', 'user_firstname');
 add_shortcode('wpuser_lastname', 'user_lastname');
 
-// query string shortcode
-add_shortcode('wpuser_query_string', 'get_query_string');
-function get_query_string($atts){
+// query param shortcode
+add_shortcode('wpuser_query_param', 'get_query_param');
+function get_query_param($atts){
     $atts = shortcode_atts( array(
         'arg' => false,
     ), $atts);
 
-    $query_string = isset( $_GET[ $atts['arg'] ] ) ? sanitize_text_field( $_GET[ $atts['arg'] ] ) : false;
-
-    return $query_string;
+    return isset( $_GET[ $atts['arg'] ] ) ? sanitize_text_field( $_GET[ $atts['arg'] ] ) : false;
 }


### PR DESCRIPTION
Add shortcode to display a query string on a page.

The shortcode:
<img width="626" alt="Screenshot 2021-10-16 at 10 22 31" src="https://user-images.githubusercontent.com/4659534/137582403-61355b31-a5ef-4f61-bd30-063de19c889b.png">

Test URL:
https://shortcodes-wp.local/sample-page/?test=Chistof+Lee

Result:
<img width="73" alt="Screenshot 2021-10-16 at 10 22 15" src="https://user-images.githubusercontent.com/4659534/137582408-fb2ce60a-8da9-408d-9e81-df34ba1c0206.png">


