### PR TITLE
implement WordPress coding standards (#7)

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -1,0 +1,24 @@
+{
+  "files": [
+    "README.md"
+  ],
+  "imageSize": 100,
+  "commit": false,
+  "contributors": [
+    {
+      "login": "ChristofLee",
+      "name": "Christof Lee",
+      "avatar_url": "https://avatars.githubusercontent.com/u/4659534?v=4",
+      "profile": "https://github.com/ChristofLee",
+      "contributions": [
+        "code"
+      ]
+    }
+  ],
+  "contributorsPerLine": 7,
+  "projectName": "shortcodes-wp",
+  "projectOwner": "ChristofLee",
+  "repoType": "github",
+  "repoHost": "https://github.com",
+  "skipCi": true
+}

--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -1,0 +1,24 @@
+{
+  "files": [
+    "README.md"
+  ],
+  "imageSize": 100,
+  "commit": false,
+  "contributors": [
+    {
+      "login": "warengonzaga",
+      "name": "Waren Gonzaga",
+      "avatar_url": "https://avatars.githubusercontent.com/u/15052701?v=4",
+      "profile": "https://bio.link/warengonzaga",
+      "contributions": [
+        "code"
+      ]
+    }
+  ],
+  "contributorsPerLine": 7,
+  "projectName": "shortcodes-wp",
+  "projectOwner": "ChristofLee",
+  "repoType": "github",
+  "repoHost": "https://github.com",
+  "skipCi": true
+}

--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -11,7 +11,8 @@
       "avatar_url": "https://avatars.githubusercontent.com/u/4659534?v=4",
       "profile": "https://github.com/ChristofLee",
       "contributions": [
-        "code"
+        "code",
+        "design"
       ]
     }
   ],

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/d
 <!-- markdownlint-disable -->
 <table>
   <tr>
-    <td align="center"><a href="https://github.com/ChristofLee"><img src="https://avatars.githubusercontent.com/u/4659534?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Christof Lee</b></sub></a><br /><a href="https://github.com/ChristofLee/shortcodes-wp/commits?author=ChristofLee" title="Code">💻</a></td>
+    <td align="center"><a href="https://github.com/ChristofLee"><img src="https://avatars.githubusercontent.com/u/4659534?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Christof Lee</b></sub></a><br /><a href="https://github.com/ChristofLee/shortcodes-wp/commits?author=ChristofLee" title="Code">💻</a> <a href="#design-ChristofLee" title="Design">🎨</a></td>
   </tr>
 </table>
 

--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ More shortcodes coming...
 
 Contributions are welcome, create a pull request to this repo and I will review your code. Please consider to submit your pull request to the ```dev``` branch. Thank you!
 
+WarenGonzaga
+
 ## 💬 Discussions
 
 For any questions, suggestions, ideas, or simply you want to share your experience in using this project, feel free to share and discuss it to the [community](https://github.com/warengonzaga/shortcodes-wp/discussions)!

--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
 # Shortcodes WP
+<!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
+[![All Contributors](https://img.shields.io/badge/all_contributors-1-orange.svg?style=flat-square)](#contributors-)
+<!-- ALL-CONTRIBUTORS-BADGE:END -->
 
 [![created by](https://img.shields.io/badge/created%20by-Waren%20Gonzaga-blue.svg?longCache=true&style=flat-square)](https://github.com/warengonzaga) [![discord](https://img.shields.io/discord/659684980137656340?color=%235865F2&label=discord&logo=discord&logoColor=white&style=flat-square)](https://wrngnz.ga/discord) [![release](https://img.shields.io/github/release/warengonzaga/shortcodes-wp.svg?style=flat-square)](https://github.com/warengonzaga/shortcodes-wp/releases) [![star](https://img.shields.io/github/stars/warengonzaga/shortcodes-wp.svg?style=flat-square)](https://github.com/warengonzaga/shortcodes-wp/stargazers) [![license](https://img.shields.io/github/license/warengonzaga/shortcodes-wp.svg?style=flat-square)](https://github.com/warengonzaga/shortcodes-wp/blob/main/license)
 
@@ -85,3 +88,23 @@ Shortcodes WP is created by **[Waren Gonzaga](https://github.com/warengonzaga)**
 [twitter]: https://twitter.com/warengonzaga
 [instagram]: https://instagram.com/warengonzagaofficial
 [youtube]: https://youtube.com/warengonzaga
+
+## Contributors ✨
+
+Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/docs/en/emoji-key)):
+
+<!-- ALL-CONTRIBUTORS-LIST:START - Do not remove or modify this section -->
+<!-- prettier-ignore-start -->
+<!-- markdownlint-disable -->
+<table>
+  <tr>
+    <td align="center"><a href="https://bio.link/warengonzaga"><img src="https://avatars.githubusercontent.com/u/15052701?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Waren Gonzaga</b></sub></a><br /><a href="https://github.com/ChristofLee/shortcodes-wp/commits?author=warengonzaga" title="Code">💻</a></td>
+  </tr>
+</table>
+
+<!-- markdownlint-restore -->
+<!-- prettier-ignore-end -->
+
+<!-- ALL-CONTRIBUTORS-LIST:END -->
+
+This project follows the [all-contributors](https://github.com/all-contributors/all-contributors) specification. Contributions of any kind welcome!

--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
 # Shortcodes WP
+<!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
+[![All Contributors](https://img.shields.io/badge/all_contributors-1-orange.svg?style=flat-square)](#contributors-)
+<!-- ALL-CONTRIBUTORS-BADGE:END -->
 
 [![created by](https://img.shields.io/badge/created%20by-Waren%20Gonzaga-blue.svg?longCache=true&style=flat-square)](https://github.com/warengonzaga) [![discord](https://img.shields.io/discord/659684980137656340?color=%235865F2&label=discord&logo=discord&logoColor=white&style=flat-square)](https://wrngnz.ga/discord) [![release](https://img.shields.io/github/release/warengonzaga/shortcodes-wp.svg?style=flat-square)](https://github.com/warengonzaga/shortcodes-wp/releases) [![star](https://img.shields.io/github/stars/warengonzaga/shortcodes-wp.svg?style=flat-square)](https://github.com/warengonzaga/shortcodes-wp/stargazers) [![license](https://img.shields.io/github/license/warengonzaga/shortcodes-wp.svg?style=flat-square)](https://github.com/warengonzaga/shortcodes-wp/blob/main/license)
 
@@ -85,3 +88,23 @@ Shortcodes WP is created by **[Waren Gonzaga](https://github.com/warengonzaga)**
 [twitter]: https://twitter.com/warengonzaga
 [instagram]: https://instagram.com/warengonzagaofficial
 [youtube]: https://youtube.com/warengonzaga
+
+## Contributors ✨
+
+Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/docs/en/emoji-key)):
+
+<!-- ALL-CONTRIBUTORS-LIST:START - Do not remove or modify this section -->
+<!-- prettier-ignore-start -->
+<!-- markdownlint-disable -->
+<table>
+  <tr>
+    <td align="center"><a href="https://github.com/ChristofLee"><img src="https://avatars.githubusercontent.com/u/4659534?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Christof Lee</b></sub></a><br /><a href="https://github.com/ChristofLee/shortcodes-wp/commits?author=ChristofLee" title="Code">💻</a></td>
+  </tr>
+</table>
+
+<!-- markdownlint-restore -->
+<!-- prettier-ignore-end -->
+
+<!-- ALL-CONTRIBUTORS-LIST:END -->
+
+This project follows the [all-contributors](https://github.com/all-contributors/all-contributors) specification. Contributions of any kind welcome!

--- a/shortcodes-wp.php
+++ b/shortcodes-wp.php
@@ -1,58 +1,58 @@
 <?php
 /**
-* Plugin Name: Shortcodes WP
-* Plugin URI: https://github.com/warengonzaga/shortcodes-wp
-* Description: A WordPress shortcode plugin to automagically display WordPress information. Simple and lightweight, no annoying ads and fancy settings.
-* Version: 1.0.0
-* Author: Waren Gonzaga
-* Author URI: https://warengonzaga.com
-*/
+ * Plugin Name: Shortcodes WP
+ * Plugin URI: https://github.com/warengonzaga/shortcodes-wp
+ * Description: A WordPress shortcode plugin to automagically display WordPress information. Simple and lightweight, no annoying ads and fancy settings.
+ * Version: 1.0.0
+ * Author: Waren Gonzaga
+ * Author URI: https://warengonzaga.com
+ */
 
 /**
-* WP Update Your Footer
-*/
+ * WP Update Your Footer
+ */
 
 // prevent direct access
-defined( 'ABSPATH' ) or die( "Restricted Access!" );
+defined( 'ABSPATH' ) or die( 'Restricted Access!' );
 
-function user_firstname($atts) {
-    $user = wp_get_current_user();
-    $firstname = $user->first_name;
-    $display_firstname = $firstname;
+function user_firstname( $atts ) {
+	$user              = wp_get_current_user();
+	$firstname         = $user->first_name;
+	$display_firstname = $firstname;
 
-    // display output
-    return $display_firstname;
+	// display output
+	return $display_firstname;
 }
 
-function user_lastname($atts) {
-    $user = wp_get_current_user();
-    $lastname = $user->last_name;
-    $display_lastname = $lastname;
+function user_lastname( $atts ) {
+	$user             = wp_get_current_user();
+	$lastname         = $user->last_name;
+	$display_lastname = $lastname;
 
-    // display output
-    return $display_lastname;
+	// display output
+	return $display_lastname;
 }
 
-// wordpress hook
-add_shortcode('wpuser_firstname', 'user_firstname');
-add_shortcode('wpuser_lastname', 'user_lastname');
+// WordPress hook
+add_shortcode( 'wpuser_firstname', 'user_firstname' );
+add_shortcode( 'wpuser_lastname', 'user_lastname' );
 
 // Current day.
-add_shortcode('wpinfo_current_day', 'current_day');
+add_shortcode( 'wpinfo_current_day', 'current_day' );
 function current_day() {
-    return gmdate( 'l' );
+	return gmdate( 'l' );
 }
 
 // Current month.
-add_shortcode('wpinfo_current_month', 'current_month');
+add_shortcode( 'wpinfo_current_month', 'current_month' );
 function current_month() {
-    return gmdate( 'F' );
+	return gmdate( 'F' );
 }
 
 // Current year.
-add_shortcode('wpinfo_current_year', 'current_year');
+add_shortcode( 'wpinfo_current_year', 'current_year' );
 function current_year() {
-    return gmdate( 'Y' );
+	return gmdate( 'Y' );
 }
 
 /**
@@ -61,21 +61,27 @@ function current_year() {
  * – Allow the user to select their own format.
  * – Else fallback to the default option.
  */
-add_shortcode('wpinfo_current_date', 'current_date');
-function current_date($atts) {
-    $default_date_format = get_option( 'date_format' );
-    $atts = shortcode_atts( array(
-        'format' => $default_date_format,
-    ), $atts );
-    return gmdate( $atts['format'] );
+add_shortcode( 'wpinfo_current_date', 'current_date' );
+function current_date( $atts ) {
+	$default_date_format = get_option( 'date_format' );
+	$atts                = shortcode_atts(
+		array(
+			'format' => $default_date_format,
+		),
+		$atts
+	);
+	return gmdate( $atts['format'] );
 }
 
 // query param shortcode
-add_shortcode('wpuser_query_param', 'get_query_param');
-function get_query_param($atts){
-    $atts = shortcode_atts( array(
-        'arg' => false,
-    ), $atts);
+add_shortcode( 'wpuser_query_param', 'get_query_param' );
+function get_query_param( $atts ) {
+	$atts = shortcode_atts(
+		array(
+			'arg' => false,
+		),
+		$atts
+	);
 
-    return isset( $_GET[ $atts['arg'] ] ) ? sanitize_text_field( $_GET[ $atts['arg'] ] ) : false;
+	return isset( $_GET[ $atts['arg'] ] ) ? sanitize_text_field( $_GET[ $atts['arg'] ] ) : false;
 }

--- a/shortcodes-wp.php
+++ b/shortcodes-wp.php
@@ -36,3 +36,15 @@ function user_lastname($atts) {
 // wordpress hook
 add_shortcode('wpuser_firstname', 'user_firstname');
 add_shortcode('wpuser_lastname', 'user_lastname');
+
+// query string shortcode
+add_shortcode('wpuser_query_string', 'get_query_string');
+function get_query_string($atts){
+    $atts = shortcode_atts( array(
+        'arg' => false,
+    ), $atts);
+
+    $query_string = isset( $_GET[ $atts['arg'] ] ) ? sanitize_text_field( $_GET[ $atts['arg'] ] ) : false;
+
+    return $query_string;
+}

--- a/shortcodes-wp.php
+++ b/shortcodes-wp.php
@@ -42,3 +42,9 @@ add_shortcode('wpinfo_current_day', 'current_day');
 function current_day() {
     return get_the_date( 'l' );
 }
+
+// Current month.
+add_shortcode('wpinfo_current_month', 'current_month');
+function current_month() {
+    return get_the_date( 'F' );
+}

--- a/shortcodes-wp.php
+++ b/shortcodes-wp.php
@@ -37,14 +37,12 @@ function user_lastname($atts) {
 add_shortcode('wpuser_firstname', 'user_firstname');
 add_shortcode('wpuser_lastname', 'user_lastname');
 
-// query string shortcode
-add_shortcode('wpuser_query_string', 'get_query_string');
-function get_query_string($atts){
+// query param shortcode
+add_shortcode('wpuser_query_param', 'get_query_param');
+function get_query_param($atts){
     $atts = shortcode_atts( array(
         'arg' => false,
     ), $atts);
 
-    $query_string = isset( $_GET[ $atts['arg'] ] ) ? sanitize_text_field( $_GET[ $atts['arg'] ] ) : false;
-
-    return $query_string;
+    return isset( $_GET[ $atts['arg'] ] ) ? sanitize_text_field( $_GET[ $atts['arg'] ] ) : false;
 }

--- a/shortcodes-wp.php
+++ b/shortcodes-wp.php
@@ -54,3 +54,18 @@ add_shortcode('wpinfo_current_year', 'current_year');
 function current_year() {
     return get_the_date( 'Y' );
 }
+
+/**
+ * Current date
+ *
+ * – Allow the user to select their own format.
+ * – Else fallback to the default option.
+ */
+add_shortcode('wpinfo_current_date', 'current_date');
+function current_date($atts) {
+    $default_date_format = get_option( 'date_format' );
+    $atts = shortcode_atts( array(
+        'format' => $default_date_format,
+    ), $atts );
+    return get_the_date( $atts['format'] );
+}

--- a/shortcodes-wp.php
+++ b/shortcodes-wp.php
@@ -12,15 +12,15 @@
  * WP Update Your Footer
  */
 
-// prevent direct access
 defined( 'ABSPATH' ) or die( 'Restricted Access!' );
+// Prevent direct access.
 
 function user_firstname( $atts ) {
 	$user              = wp_get_current_user();
 	$firstname         = $user->first_name;
 	$display_firstname = $firstname;
 
-	// display output
+	// Display output.
 	return $display_firstname;
 }
 
@@ -29,11 +29,11 @@ function user_lastname( $atts ) {
 	$lastname         = $user->last_name;
 	$display_lastname = $lastname;
 
-	// display output
+	// Display output.
 	return $display_lastname;
 }
 
-// WordPress hook
+// WordPress hook.
 add_shortcode( 'wpuser_firstname', 'user_firstname' );
 add_shortcode( 'wpuser_lastname', 'user_lastname' );
 
@@ -73,7 +73,7 @@ function current_date( $atts ) {
 	return gmdate( $atts['format'] );
 }
 
-// query param shortcode
+// Query param shortcode.
 add_shortcode( 'wpuser_query_param', 'get_query_param' );
 function get_query_param( $atts ) {
 	$atts = shortcode_atts(

--- a/shortcodes-wp.php
+++ b/shortcodes-wp.php
@@ -15,6 +15,8 @@
 // prevent direct access
 defined( 'ABSPATH' ) or die( "Restricted Access!" );
 
+echo get_the_date();
+
 function user_firstname($atts) {
     $user = wp_get_current_user();
     $firstname = $user->first_name;
@@ -40,19 +42,19 @@ add_shortcode('wpuser_lastname', 'user_lastname');
 // Current day.
 add_shortcode('wpinfo_current_day', 'current_day');
 function current_day() {
-    return get_the_date( 'l' );
+    return gmdate( 'l' );
 }
 
 // Current month.
 add_shortcode('wpinfo_current_month', 'current_month');
 function current_month() {
-    return get_the_date( 'F' );
+    return gmdate( 'F' );
 }
 
 // Current year.
 add_shortcode('wpinfo_current_year', 'current_year');
 function current_year() {
-    return get_the_date( 'Y' );
+    return gmdate( 'Y' );
 }
 
 /**
@@ -67,5 +69,5 @@ function current_date($atts) {
     $atts = shortcode_atts( array(
         'format' => $default_date_format,
     ), $atts );
-    return get_the_date( $atts['format'] );
+    return gmdate( $atts['format'] );
 }

--- a/shortcodes-wp.php
+++ b/shortcodes-wp.php
@@ -12,8 +12,8 @@
  * WP Update Your Footer
  */
 
-defined( 'ABSPATH' ) or die( 'Restricted Access!' );
 // Prevent direct access.
+defined( 'ABSPATH' ) || die( 'Restricted Access!' );
 
 function user_firstname( $atts ) {
 	$user              = wp_get_current_user();

--- a/shortcodes-wp.php
+++ b/shortcodes-wp.php
@@ -12,7 +12,7 @@
  * WP Update Your Footer
  */
 
-// Prevent direct access.
+// prevent direct access.
 defined( 'ABSPATH' ) || die( 'Restricted Access!' );
 
 function user_firstname( $atts ) {
@@ -20,7 +20,7 @@ function user_firstname( $atts ) {
 	$firstname         = $user->first_name;
 	$display_firstname = $firstname;
 
-	// Display output.
+	// display output.
 	return $display_firstname;
 }
 
@@ -29,27 +29,27 @@ function user_lastname( $atts ) {
 	$lastname         = $user->last_name;
 	$display_lastname = $lastname;
 
-	// Display output.
+	// display output.
 	return $display_lastname;
 }
 
-// WordPress hook.
+// wordPress hook.
 add_shortcode( 'wpuser_firstname', 'user_firstname' );
 add_shortcode( 'wpuser_lastname', 'user_lastname' );
 
-// Current day.
+// current day.
 add_shortcode( 'wpinfo_current_day', 'current_day' );
 function current_day() {
 	return gmdate( 'l' );
 }
 
-// Current month.
+// current month.
 add_shortcode( 'wpinfo_current_month', 'current_month' );
 function current_month() {
 	return gmdate( 'F' );
 }
 
-// Current year.
+// current year.
 add_shortcode( 'wpinfo_current_year', 'current_year' );
 function current_year() {
 	return gmdate( 'Y' );
@@ -73,7 +73,7 @@ function current_date( $atts ) {
 	return gmdate( $atts['format'] );
 }
 
-// Query param shortcode.
+// query param shortcode.
 add_shortcode( 'wpuser_query_param', 'get_query_param' );
 function get_query_param( $atts ) {
 	$atts = shortcode_atts(

--- a/shortcodes-wp.php
+++ b/shortcodes-wp.php
@@ -48,3 +48,9 @@ add_shortcode('wpinfo_current_month', 'current_month');
 function current_month() {
     return get_the_date( 'F' );
 }
+
+// Current year.
+add_shortcode('wpinfo_current_year', 'current_year');
+function current_year() {
+    return get_the_date( 'Y' );
+}

--- a/shortcodes-wp.php
+++ b/shortcodes-wp.php
@@ -36,3 +36,9 @@ function user_lastname($atts) {
 // wordpress hook
 add_shortcode('wpuser_firstname', 'user_firstname');
 add_shortcode('wpuser_lastname', 'user_lastname');
+
+// Current day.
+add_shortcode('wpinfo_current_day', 'current_day');
+function current_day() {
+    return get_the_date( 'l' );
+}

--- a/shortcodes-wp.php
+++ b/shortcodes-wp.php
@@ -83,5 +83,5 @@ function get_query_param( $atts ) {
 		$atts
 	);
 
-	return isset( $_GET[ $atts['arg'] ] ) ? sanitize_text_field( $_GET[ $atts['arg'] ] ) : false;
+	return isset( $_GET[ $atts['arg'] ] ) ? sanitize_text_field( wp_unslash( $_GET[ $atts['arg'] ] ) ) : false;
 }


### PR DESCRIPTION
This is an example of we can use PHPCS and PHPCBF to format our code and standardise it.

Solves #7.